### PR TITLE
Add processing for `data-asset-id` attributes on anchors

### DIFF
--- a/lib/translation/extraction/items-extraction.processor.ts
+++ b/lib/translation/extraction/items-extraction.processor.ts
@@ -59,6 +59,10 @@ export function itemsExtractionProcessor() {
                                 .processAssetIds(rteValue ?? '')
                                 .ids.forEach((id) => extractedIds.assetIds.add(id));
 
+                            richTextProcessor()
+                                .processLinkAssetIds(rteValue ?? '')
+                                .ids.forEach((id) => extractedIds.assetIds.add(id));
+
                             // recursively extract data from components as well because they may reference additional assets & content items
                             const extractedComponents = extractReferencedDataFromExtractItems(
                                 itemElement.components.map((component) => {
@@ -124,6 +128,10 @@ export function itemsExtractionProcessor() {
                                 // assets
                                 richTextProcessor()
                                     .processAssetCodenames(richTextHtml)
+                                    .codenames.forEach((codename) => childExtractedCodenames.assetCodenames.add(codename));
+
+                                richTextProcessor()
+                                    .processLinkAssetCodenames(richTextHtml)
                                     .codenames.forEach((codename) => childExtractedCodenames.assetCodenames.add(codename));
 
                                 // recursively extract data from components as well because they may reference additional assets & content items

--- a/lib/translation/transforms/export-transforms.ts
+++ b/lib/translation/transforms/export-transforms.ts
@@ -243,6 +243,19 @@ function transformRichTextValue(
         };
     }).html;
 
+    // replace link asset ids with codenames
+    richTextHtml = richTextProcessor().processLinkAssetIds(richTextHtml, (id) => {
+        const assetInEnv = context.getAssetStateInSourceEnvironment(id).asset;
+
+        if (!assetInEnv) {
+            throw Error(`Failed to get asset with id '${chalk.red(id)}'`);
+        }
+
+        return {
+            codename: assetInEnv.codename
+        };
+    }).html;
+
     return {
         components: exportElement.components,
         value: richTextHtml

--- a/lib/translation/transforms/import-transforms.ts
+++ b/lib/translation/transforms/import-transforms.ts
@@ -211,5 +211,10 @@ function processImportRichTextHtmlValue(data: {
         return data.importContext.getAssetStateInTargetEnvironment(codename);
     }).html;
 
+    // replace link asset codenames with existing codename or external_id
+    richTextHtml = richTextProcessor().processLinkAssetCodenames(richTextHtml, (codename) => {
+        return data.importContext.getAssetStateInTargetEnvironment(codename);
+    }).html;
+
     return richTextHtml;
 }


### PR DESCRIPTION
### Motivation

Imports of data would fail if the exported data included asset links.
Ex: `<a data-asset-id="47213619-2265-4e32-88d3-13d25cba7a1f">...</a>`

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?

Run an export and import of a content item including rich text that has an asset link.